### PR TITLE
Parse out only first slash on healthcheck path

### DIFF
--- a/copy_classic_load_balancer.py
+++ b/copy_classic_load_balancer.py
@@ -241,7 +241,7 @@ def get_alb_data(elb_data, region, load_balancer_name):
             'HealthyThreshold']
         target_group['UnhealthyThresholdCount'] = elb_data['LoadBalancerDescriptions'][0]['HealthCheck'][
             'UnhealthyThreshold']
-        target_group['HealthCheckPath'] = '/' + hc_target.split('/')[1]
+        target_group['HealthCheckPath'] = '/' + hc_target.split('/', 1)[1]
         target_group['HealthCheckPort'] = hc_target[hc_target.index(':') + 1:hc_target.index('/')]
 
         target_group['HealthCheckProtocol'] = hc_target.split(':')[0]
@@ -464,4 +464,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/copy_classic_load_balancer.py
+++ b/copy_classic_load_balancer.py
@@ -464,3 +464,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
The healthcheck paths we use at our organization isn't at the root level, which this seems to be assuming. We need to pass in the number maximum number of delimiters to split in the `String.split()` method.

```
>>> 'HTTP:6341/internal/healthcheck'.split("/")[1]
'internal'
>>> 'HTTP:6341/internal/healthcheck'.split("/", 1)[1]
'internal/healthcheck'
```