### PR TITLE
removing tags prefixed with aws: as this is reserved namespace

### DIFF
--- a/copy_classic_load_balancer.py
+++ b/copy_classic_load_balancer.py
@@ -97,6 +97,10 @@ def get_elb_data(elb_name, region):
 
     describe_tags = elbc.describe_tags(
         LoadBalancerNames=[elb_name])
+    #remove aws: tags as it is reserved namespace
+    describe_tags['TagDescriptions'][0]['Tags'] = [tag for tag in \
+        describe_tags['TagDescriptions'][0]['Tags'] \
+        if not tag['Key'].startswith('aws:')]
 
     # Render a dictionary that contains load balancer attributes
     elb_data = {}
@@ -464,4 +468,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
This should resolve Issue #6 for ELBs where an AWS service creates tags which are prefixed with "aws:". Since this namespace is reserved it is important that we remove these tags before creating an Application Load Balancer.