### PR TITLE
Fixing service definition from Issue #16

### DIFF
--- a/network-load-balancer-copy-utility/copy_network_load_balancer.py
+++ b/network-load-balancer-copy-utility/copy_network_load_balancer.py
@@ -511,7 +511,7 @@ def main():
     global client
     session = botocore.session.get_session()
     session.user_agent_name = 'CopyClassicToNetwork/' + VERSION
-    client = session.create_client('nlb', region_name=region)
+    client = session.create_client('elbv2', region_name=region)
     ec2_client = session.create_client('ec2', region_name=region)
 
     # If input gets allocation ID. Verify allocation ID


### PR DESCRIPTION
This pull request should fix the issue with Issue #16 which causes a botocore.exceptions.UnknownServiceError exception.  Boto3 is using elbv2 service definition and not a new one called nlb.  