### PR TITLE
use correct dash character

### DIFF
--- a/application-load-balancer-copy-utility/README.md
+++ b/application-load-balancer-copy-utility/README.md
@@ -16,7 +16,7 @@ copy_classic_load_balancer.py
 
 Example 1: Test whether the load balancer configuration is supported
 ```
-copy_classic_load_balancer.py --name my-load-balancer -–region us-west-2 --dry-run
+copy_classic_load_balancer.py --name my-load-balancer --region us-west-2 --dry-run
 ```
 
 Example 2: Create an Application load balancer based on the specified Classic load balancer but do not register the instances as targets


### PR DESCRIPTION
The readme used an "en dash" instead of a hyphen.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
