### PR TITLE
Added fields/query example for http-guardian

### DIFF
--- a/amazon-athena-for-elb/Analyzing_ALB_Access_Logs_with_Amazon_Athena.md
+++ b/amazon-athena-for-elb/Analyzing_ALB_Access_Logs_with_Amazon_Athena.md
@@ -7,46 +7,45 @@ Setup steps:
 3. Setup your new database and table refer to https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html#create-alb-table for the latest query to create the table
 ```sql
 CREATE EXTERNAL TABLE IF NOT EXISTS alb_logs (
-            type string,
-            time string,
-            elb string,
-            client_ip string,
-            client_port int,
-            target_ip string,
-            target_port int,
-            request_processing_time double,
-            target_processing_time double,
-            response_processing_time double,
-            elb_status_code string,
-            target_status_code string,
-            received_bytes bigint,
-            sent_bytes bigint,
-            request_verb string,
-            request_url string,
-            request_proto string,
-            user_agent string,
-            ssl_cipher string,
-            ssl_protocol string,
-            target_group_arn string,
-            trace_id string,
-            domain_name string,
-            chosen_cert_arn string,
-            matched_rule_priority string,
-            request_creation_time string,
-            actions_executed string,
-            redirect_url string,
-            lambda_error_reason string,
-            target_port_list string,
-            target_status_code_list string,
-            classification string,
-            classification_reason string
-            )
-            ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'
-            WITH SERDEPROPERTIES (
-            'serialization.format' = '1',
-            'input.regex' = 
-        '([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) ([^ ]*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\s]+?)\" \"([^\s]+)\" \"([^ ]*)\" \"([^ ]*)\"')
-            LOCATION 's3://your-alb-logs-directory/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/<REGION>/';
+    type string,
+    time string,
+    elb string,
+    client_ip string,
+    client_port int,
+    target_ip string,
+    target_port int,
+    request_processing_time double,
+    target_processing_time double,
+    response_processing_time double,
+    elb_status_code string,
+    target_status_code string,
+    received_bytes bigint,
+    sent_bytes bigint,
+    request_verb string,
+    request_url string,
+    request_proto string,
+    user_agent string,
+    ssl_cipher string,
+    ssl_protocol string,
+    target_group_arn string,
+    trace_id string,
+    domain_name string,
+    chosen_cert_arn string,
+    matched_rule_priority string,
+    request_creation_time string,
+    actions_executed string,
+    redirect_url string,
+    lambda_error_reason string,
+    new_field string,
+    classification string,
+    classification_reason string
+    )
+    ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'
+    WITH SERDEPROPERTIES (
+    'serialization.format' = '1',
+    'input.regex' = 
+'([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) ([^ ]*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\"($| \"[^ ]*\")(.*)')
+    LOCATION 's3://your-alb-logs-directory/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/region';
 ```
 4. Run queries
 ### Select data information for time period


### PR DESCRIPTION
*Description of changes:*

More info https://github.com/aws/http-desync-guardian/tree/master/docs#overview
Verified on a test ALB.
```
22	73551	POST	-	-
19	47392	-	-	-
21	22065	GET	-	-
15	21671	GET	Acceptable	GetHeadZeroContentLength
24	20114	POST	Ambiguous	SuspiciousHeader
23	4462	PUT	-	-
5	4460	POST	Acceptable	NonCompliantHeader
11	3748	POST	Ambiguous	BothTeClPresent
6	2976	PUT	Acceptable	NonCompliantHeader
4	2975	GET	Acceptable	NonCompliantVersion
18	2975	POST	Ambiguous	EmptyHeader
9	2289	GET	Ambiguous	UndefinedContentLengthSemantics
3	2230	GET	Ambiguous	UndefinedTransferEncodingSemantics
13	2229	POST	Severe	MultipleContentLength
28	2229	POST	Severe	MultipleTransferEncodingChunked
29	2229	GET	Ambiguous	AmbiguousUri
26	1488			
12	1487	HEAD	Ambiguous	UndefinedContentLengthSemantics
25	1487	POST	Ambiguous	UndefinedTransferEncodingSemantics
10	759	POST	Severe	BadTransferEncoding
1	744	HEAD	Ambiguous	UndefinedTransferEncodingSemantics
8	744	HEAD	Acceptable	GetHeadZeroContentLength
20	59	HEAD	-	-
7	28	PROPFIND	-	-
16	21	OPTIONS	-	-
27	4	SSTP_DUPLEX_POST	-	-
2	1	DLKZUX	-	-
14	1	KZFZYW	-	-
17	1	MKZSRM	-	-
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
