### PR TITLE
Fix infinite loop when resetting LCU capacity to zero in scheduler-lcu-reservation tool

### DIFF
--- a/scheduler-lcu-reservation/templates/capacity-reservation-scheduler.yml
+++ b/scheduler-lcu-reservation/templates/capacity-reservation-scheduler.yml
@@ -261,6 +261,10 @@ Resources:
                   # Make the API call with the constructed parameters
                   response = elbv2_client.modify_capacity_reservation(**params)
 
+                  # Initialize status_code and status variables
+                  status_code = None
+                  status = "FAILURE"  # Default to failure
+                  
                   # Wait for capacity reservation to be provisioned or failed
                   while True:
                       response = elbv2_client.describe_capacity_reservation(
@@ -269,19 +273,42 @@ Resources:
 
                       logger.info(f"describe_capacity_reservation response: {response}")
 
-                      if response['CapacityReservationState']:
-                          status_code = response['CapacityReservationState'][0]['State']['Code']
-                   
-                          if status_code in ['provisioned', 'failed']:
+                      # Case 1: Reset to 0 - CapacityReservationState will be empty
+                      if reset_capacity_reservation and not response.get('CapacityReservationState'):
+                          status_code = 'provisioned'  # Consider empty state as success for reset
+                          status = "SUCCESS"
+                          break
+                      
+                      # Case 2: Provisioning LCU - Check all AZs for provisioning status
+                      elif response.get('CapacityReservationState'):
+                          # Check if all AZs are in the desired state
+                          all_provisioned = True
+                          any_failed = False
+                          
+                          for reservation in response['CapacityReservationState']:
+                              state_code = reservation['State']['Code']
+                              if state_code != 'provisioned':
+                                  all_provisioned = False
+                              if state_code == 'failed':
+                                  any_failed = True
+                          
+                          if all_provisioned:
+                              status_code = 'provisioned'
+                              status = "SUCCESS"
                               break
-                                          
+                          elif any_failed:
+                              status_code = 'failed'
+                              status = "FAILURE"
+                              break
+                          # If some are still pending, continue the loop
+                      
+                      # Sleep between API calls to avoid throttling
                       time.sleep(5)
-
+                  
+                  # Set message based on final status
                   if status_code == 'provisioned':
-                      status = "SUCCESS"
                       message = f"Successfully modified and provisioned capacity reservation for ELB: {elb_arn}"
                   else:
-                      status = "FAILURE" 
                       message = f"Failed to provision capacity reservation for ELB: {elb_arn}"
 
                   logger.info(f"Status: {status}, Message: {message}")


### PR DESCRIPTION
## Issue Description
The Lambda function responsible for modifying ELB capacity reservations contains a bug that causes it to enter an infinite loop when resetting capacity to zero (0). This results in Lambda timeouts and potential operational impacts.

## Root Cause
When a capacity reservation is reset to zero using `ResetCapacityReservation: true`, the ELB API returns a response with an empty `CapacityReservationState` array:

```json
{
    "DecreaseRequestsRemaining": 1,
    "CapacityReservationState": []
}
```
The current monitoring loop checks for completion by looking for a non-empty CapacityReservationState array, which never happens after a reset operation:
```
while True:
    response = elbv2_client.describe_capacity_reservation(
        LoadBalancerArn=elb_arn
    )

    if response['CapacityReservationState']:
        status_code = response['CapacityReservationState'][0]['State']['Code']
     
        if status_code in ['provisioned', 'failed']:
            break
                            
    time.sleep(5)
```
This causes the code to continue looping indefinitely until Lambda times out.

## Changes Made
This PR modifies the monitoring loop to properly handle both scenarios:
* For reset operations (desired_lcu = 0): Considers an empty CapacityReservationState array as success
* For provisioning operations: Properly checks all AZs for completion status
* Handles pending states by continuing to wait for a definitive outcome
This fix prevents Lambda timeouts and ensures proper notification of operation completion.

## Testing
Tested with both reset operations (desired_lcu = 0) and provisioning operations (desired_lcu > 0) to verify proper handling of all states.